### PR TITLE
Bump minimum tldextract version to 5.3 -- fix deprecated property

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ iso3166>=0.4
 pylru>=1.0.3
 pytest
 ruamel.yaml
-tldextract>=1.2
+tldextract>=5.3

--- a/serpextract/serpextract.py
+++ b/serpextract/serpextract.py
@@ -499,7 +499,7 @@ def get_all_query_params_by_domain():
         # Find non-regex params
         params = {param for param in parser.keyword_extractor if isinstance(param, str)}
         tld_res = tldextract.extract(domain)
-        domain = tld_res.registered_domain
+        domain = tld_res.top_domain_under_public_suffix
         param_dict[domain] = sorted(set(param_dict[domain]) | params)
     _qs_params = param_dict
     return param_dict


### PR DESCRIPTION
https://github.com/john-kurkowski/tldextract/blob/6e49ea583c85a80e82ae5554cd615e8ee305a026/CHANGELOG.md

Since we're making breaking changes w.r.t. python minimum versions, let's make sure users of this lib take advantage of the performance improvements in tldextract.